### PR TITLE
Ask user input game path when Inject.AssemblyFolder is not valid.

### DIFF
--- a/RainWorldInject/RainWorldInject.csproj
+++ b/RainWorldInject/RainWorldInject.csproj
@@ -57,6 +57,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="src\ConfigManager.cs" />
     <Compile Include="src\Injector.cs" />
     <Compile Include="src\Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/RainWorldInject/src/ConfigManager.cs
+++ b/RainWorldInject/src/ConfigManager.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace RainWorldInject
+{
+    class ConfigManager : IDisposable
+    {
+        private bool isDirty = false;
+        private string configFileName = null;
+        private readonly Dictionary<string, string> configRawDictionary = new Dictionary<string, string>();
+        private readonly Dictionary<string, object> configParsedDictionary = new Dictionary<string, object>();
+
+        public ConfigManager(string fileName) {
+            LoadConfig(fileName, true); // change to false so will not create new file if there was no configure file
+        }
+
+        ~ConfigManager() {
+            Dispose();
+        }
+
+        #region Load and Save
+        public void LoadConfig(string fileName, bool forceCreate) {
+            configRawDictionary.Clear();
+            configParsedDictionary.Clear();
+
+            if (ParseConfigFile(fileName) || forceCreate) configFileName = fileName;
+        }
+
+        private bool ParseConfigFile(string fileName) {
+
+            if (!File.Exists(fileName)) return false;
+
+            try {
+                using (StreamReader sr = File.OpenText(fileName))
+                    while (!sr.EndOfStream) {
+                        string line = sr.ReadLine();
+                        if (line.Length < 3) continue;
+                        if (line.StartsWith(@"#")) continue;
+
+                        int equals = line.IndexOf('=');
+                        string key = line.Remove(equals).Trim();
+                        string value = line.Substring(equals + 1).Trim();
+                        configRawDictionary[key] = value;
+                    }
+            } catch (Exception e) {
+                Console.WriteLine(e.ToString());
+            }
+
+            return true;
+        }
+
+        public bool SaveConfig() {
+            if (configFileName == null) {
+                Console.WriteLine("No configuration filename specify, will not save to file...");
+                return false;
+            }
+
+            if (!isDirty) return true; // not dirty = no need to save.
+            bool retVal = DoWriteToFile(configFileName);
+            if (retVal) isDirty = false;
+
+            return retVal;
+        }
+
+        private bool DoWriteToFile(string filename) {
+            try {
+                StringBuilder sb = new StringBuilder();
+
+                foreach (KeyValuePair<string, string> p in configRawDictionary)
+                    sb.AppendLine(p.Key + @" = " + p.Value);
+
+                File.WriteAllText(filename, sb.ToString());
+            }
+            catch (Exception e) {
+                Console.WriteLine(e.ToString());
+                return false;
+            }
+            return true;
+        }
+        #endregion
+
+        #region GetValue and SetValue
+        public T GetValue<T>(string key, T defaultValue) {
+
+            // return if we already parsed this value.
+            if (configParsedDictionary.TryGetValue(key, out var obj)) return (T)obj;
+            // return if we really doesn't have that value from config file
+            if (!configRawDictionary.TryGetValue(key, out var raw)) return defaultValue;
+            // we have, but not parsed. parse and return value.
+            string dateType = typeof(T).Name;
+            switch (dateType) {
+                case @"Boolean":
+                    obj = raw[0] == '1';
+                    break;
+                case @"Int32":
+                    obj = int.Parse(raw);
+                    break;
+                case @"Int64":
+                    obj = Int64.Parse(raw);
+                    break;
+                case @"String":
+                    obj = raw;
+                    break;
+            }
+
+            configParsedDictionary[key] = obj;
+            configRawDictionary[key] = raw; // not neccessary though.
+
+            return (T)obj;
+        }
+
+        public void SetValue<T>(string key, T value) {
+
+            switch (typeof(T).Name) {
+                case @"Boolean":
+                    configRawDictionary[key] = value.ToString() == @"True" ? @"1" : @"0";
+                    break;
+                default:
+                    configRawDictionary[key] = value?.ToString();
+                    break;
+            }
+
+            // T is already a known type so fill parsed.
+            configParsedDictionary[key] = value;
+
+            isDirty = true;
+            SaveConfig();
+        }
+        #endregion
+
+        #region IDisposable Support
+        public void Dispose() {
+            if (isDirty) {
+                SaveConfig();
+            }
+        }
+        #endregion
+    }
+}

--- a/RainWorldInject/src/Injector.cs
+++ b/RainWorldInject/src/Injector.cs
@@ -19,10 +19,10 @@ namespace RainWorldInject {
     /// Based on: http://www.codersblock.org/blog//2014/06/integrating-monocecil-with-unity.html
     /// 
     /// Created by Martijn Zandvliet, 10/01/2017
-    public static class Injector {
-        public const string AssemblyFolder = "RainWorld_Data\\Managed";
+    public class Injector {
+        public string AssemblyFolder = @"RainWorld_Data\Managed";
 
-        public static bool Inject() {
+        public bool Inject() {
             Console.WriteLine("Rain World Mod Loader: Code Injection...\n");
 
             string assemblyPath = Path.Combine(AssemblyFolder, "Assembly-CSharp.dll");
@@ -78,7 +78,7 @@ namespace RainWorldInject {
             return true;
         }
 
-        private static bool Backup(string assemblyPath, string backupPath) {
+        private bool Backup(string assemblyPath, string backupPath) {
             // Todo: first verify that assembly is original, with md5 hash
 
             // Handle old filenames, if present
@@ -102,7 +102,7 @@ namespace RainWorldInject {
             return true;
         }
 
-        private static void ProcessAssembly(AssemblyDefinition assembly) {
+        private void ProcessAssembly(AssemblyDefinition assembly) {
             foreach (ModuleDefinition module in assembly.Modules) {
                 Console.WriteLine("Module: " + module.FullyQualifiedName);
 
@@ -136,7 +136,7 @@ namespace RainWorldInject {
             }
         }
 
-        private static void InstrumentRainworldStartMethod(MethodDefinition method, ModuleDefinition module) {
+        private void InstrumentRainworldStartMethod(MethodDefinition method, ModuleDefinition module) {
             Console.WriteLine("Patching target method: " + method.Name);
 
             ILProcessor il = method.Body.GetILProcessor();

--- a/RainWorldInject/src/Program.cs
+++ b/RainWorldInject/src/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 /// Rain World mod loader concept
 ///
@@ -20,18 +21,41 @@
 namespace RainWorldInject {
     class Program {
         static void Main(string[] args) {
-            bool success = Injector.Inject();
+
+            Injector injector = new Injector();
+            ConfigManager config = new ConfigManager("RainWorldInject.conf");
+
+            string path = config.GetValue("GamePath", @""); 
+
+            while (!CheckGameFolderValid(path)) {
+                Console.WriteLine("Please enter the game path where RainWorld.exe located:");
+                path = Console.ReadLine();
+            }
+            injector.AssemblyFolder = Path.Combine(path, @"RainWorld_Data\Managed");
+
+            bool success = false;
+            try {
+                success = injector.Inject();
+            } catch (Exception e) { // this might happen, eg. missing dll
+                Console.WriteLine("!! Error when trying to inject, {0} !!", e.Message);
+            }
 
             Console.WriteLine();
             if (success) {
+                config.SetValue("GamePath", path); // save config here so the saved value is valid.
                 Console.WriteLine("All done, enjoy!\n");
-            }
-            else {
+            } else {
                 Console.WriteLine("Something went wrong, quitting...\n");
             }
             
             Console.WriteLine("Press any key to exit...");
             Console.ReadLine();
+        }
+
+        public static bool CheckGameFolderValid(string path) {
+            if (!File.Exists(Path.Combine(path, @"RainWorld.exe"))) return false;
+            if (!File.Exists(Path.Combine(path, @"RainWorld_Data\Managed\Assembly-CSharp.dll"))) return false;
+            return true;
         }
     }
 }


### PR DESCRIPTION
I hope this will improve the user experence and better dev-coop.

I added a check for inject.AssemblyFolder to make sure it's the game's assembly folder, if it isn't, RainWorldInject will ask user for the game location path. Once user patch the assembly successful, it will save the game path value to a configure file `RainWorldInject.conf`.

To make Program can access and change inject.AssemblyFolder, I made Inject from a static class to a normal class. The config manager is in a seprate class with some tiny but useful functions. So we can also use it for other purpose than remember game path. I also add a try catch around inject.inject(), the exception may happen in some case like missing dll.

Hope it helps!
Gary Wang.